### PR TITLE
#168969539 Users can view own cars

### DIFF
--- a/src/controllers/UserController.js
+++ b/src/controllers/UserController.js
@@ -156,7 +156,7 @@ class UserController {
    */
   static async updateProfile(req, res) {
     try {
-      const userExist = await User.findOne({ _id: req.body.id });
+      const userExist = await User.findOne({ _id: req.decoded.id });
       if (userExist) {
         if (userExist.isVerified === false) {
           return HelperMethods.clientError(

--- a/src/routes/carRoute.js
+++ b/src/routes/carRoute.js
@@ -2,11 +2,20 @@ import { CarController } from '../controllers';
 import { Authorization } from '../middlewares';
 
 const UploadRoute = app => {
-  app.post('/api/v1/car/upload', Authorization.checkToken, CarController.addCar);
+  app.post('/api/v1/car/upload',
+    Authorization.checkToken,
+    CarController.addCar);
+  app.post('/api/v1/upload/one',
+    Authorization.checkToken,
+    CarController.uploadOne);
   app.patch('/api/v1/car/update',
     Authorization.checkToken,
     CarController.updateCarInformation);
-  app.post('/api/v1/upload/one', Authorization.checkToken, CarController.uploadOne);
+  app.get('/api/v1/owner/cars',
+    Authorization.checkToken,
+    CarController.findCarsOfDriverPrivate);
+  app.get('/api/v1/owner/cars/public',
+    CarController.findCarsOfDriverPublic);
 };
 
 export default UploadRoute;


### PR DESCRIPTION
#### What does this PR do?
Avail all users cars
#### Description of Task to be completed?

- Create an endpoint that can avail all the list of a user's cars upon request. 
- Create a private token protected route where only a car owner can view list of all his cars
- Create a public route where a list of an owner's cars can be viewed by other users only if his profile is public
#### How should this be manually tested?

- clone this branch
- cd into the project directory
- run yarn install to install all the dependencies
- run `yarn dev-start

- navigate to `localhost:<PORT>/api/v1/owner/cars` and make a `GET` request with the owner's token. A response in JSON format containing the list of a user's cars will be returned as shown below

![Screenshot from 2019-10-06 04-05-00](https://user-images.githubusercontent.com/47578865/66263667-9f28e180-e7ee-11e9-9100-77728f450d56.png)

- navigate to `localhost:<PORT>/api/v1/owner/cars/public` and make a `GET` request with the owner's id. A response in JSON format containing the list of a user's cars will also be returned as is the case above

#### What are the relevant pivotal tracker stories?
#168969539 