### PR TITLE
#169062913 User (Owner) can update the status of a request

### DIFF
--- a/src/controllers/RequestController.js
+++ b/src/controllers/RequestController.js
@@ -8,7 +8,7 @@ import { HelperMethods } from '../utils';
  */
 class RequestController {
   /**
-   * Sign up a user
+   * Create a new request
    * Route: POST: /request
    * @param {object} req - HTTP Request object
    * @param {object} res - HTTP Response object
@@ -19,7 +19,7 @@ class RequestController {
     const { body: { carId }, decoded: { id } } = req;
     try {
       const requests = await Request.find({ driver: id, carId, });
-      if (requests) {
+      if (requests.length) {
         return HelperMethods.clientError(res, 'it appears this request already exists');
       }
       const carExist = await Car.findById(carId);
@@ -29,11 +29,46 @@ class RequestController {
       }
 
       const request = new Request({
-        carId: carExist.owner,
+        carId,
         driver: id,
       });
       await request.save();
       return HelperMethods.requestSuccessful(res, request, 201);
+    } catch (error) {
+      return HelperMethods.serverError(res, error.message);
+    }
+  }
+
+  /**
+   * Create a new request
+   * Route: POST: /request
+   * @param {object} req - HTTP Request object
+   * @param {object} res - HTTP Response object
+   * @return {res} res - HTTP Response object
+   * @memberof RequestController
+   */
+  static async updateRequestStatus(req, res) {
+    const { body: { requestId, status }, decoded: { id } } = req;
+    try {
+      const requests = await Request.findById({ _id: requestId });
+      if (!requests) {
+        return HelperMethods.clientError(res, 'it appears this request does not exists');
+      }
+      if (requests.status === 'closed') {
+        return HelperMethods.clientError(res, 'a closed request cannot be updated');
+      }
+      const carExist = await Car.findById(requests.carId);
+      if (!carExist) return HelperMethods.clientError(res, 'car not found');
+      if (carExist.status !== 'available') {
+        return HelperMethods.clientError(res, 'This car is no longer available');
+      }
+      if (id !== carExist.owner.toString()) {
+        return HelperMethods.clientError(res,
+          'you are not authorized to update this request');
+      }
+      await Request.updateOne({ _id: requestId }, { $set: { status } });
+      return HelperMethods.requestSuccessful(res,
+        'request status has been updated successfully', 200);
     } catch (error) {
       return HelperMethods.serverError(res, error.message);
     }

--- a/src/routes/requestRoute.js
+++ b/src/routes/requestRoute.js
@@ -5,5 +5,8 @@ const requestRoute = app => {
   app.post('/api/v1/request',
     Authorization.checkToken,
     RequestController.createRequest);
+  app.patch('/api/v1/request',
+    Authorization.checkToken,
+    RequestController.updateRequestStatus);
 };
 export default requestRoute;


### PR DESCRIPTION
#### What does this PR do?
Allows a car owner to change the status of a request
#### Description of Task to be completed?
Create a route where a driver can change the status of his requests
#### How should this be manually tested?
- clone this branch
- cd into the project directory
- run yarn install to install all the dependencies
- run `yarn dev-start

- navigate to `localhost:<PORT>/api/v1/request` and make a `PATCH` request with the the car id and the new status. A response in JSON format containing the response from the request will be returned

![Screenshot from 2019-10-10 13-49-48](https://user-images.githubusercontent.com/47578865/66570176-f7504280-eb64-11e9-95f3-f14303755d5f.png)



#### What are the relevant pivotal tracker stories?
#169062913
